### PR TITLE
Trivial fix to make documentation match the code.

### DIFF
--- a/lib/Dancer/Plugin/REST.pm
+++ b/lib/Dancer/Plugin/REST.pm
@@ -223,8 +223,8 @@ This keyword lets you declare a resource your application will handle.
     # this defines the following routes:
     # GET /user/:id
     # GET /user/:id.:format
-    # POST /user/create
-    # POST /user/create.:format
+    # POST /user
+    # POST /user.:format
     # DELETE /user/:id
     # DELETE /user/:id.:format
     # PUT /user/:id


### PR DESCRIPTION
Fix the POST URIs in the documentation to match the routes created by the code.
